### PR TITLE
Improved entity handling

### DIFF
--- a/.idea/runConfigurations/build.xml
+++ b/.idea/runConfigurations/build.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="build" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/index_js.xml
+++ b/.idea/runConfigurations/index_js.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="driver.js" type="NodeJSConfigurationType" nameIsGenerated="true" path-to-js-file="driver.js" working-dir="$PROJECT_DIR$">
+  <configuration default="false" name="index.js" type="NodeJSConfigurationType" nameIsGenerated="true" path-to-js-file="dist/index.js" working-dir="$PROJECT_DIR$">
     <envs>
+      <env name="DEBUG" value="ucapi:*" />
       <env name="UC_CONFIG_HOME" value="$PROJECT_DIR$" />
       <env name="UC_INTEGRATION_HTTP_PORT" value="8098" />
     </envs>

--- a/.idea/runConfigurations/start.xml
+++ b/.idea/runConfigurations/start.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="start" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="start" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs>
+      <env name="DEBUG" value="*" />
+      <env name="UC_CONFIG_HOME" value="$PROJECT_DIR$" />
+      <env name="UC_INTEGRATION_HTTP_PORT" value="8098" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Breaking Changes
+
+- Setup flow must be run on the Remote to make sure the Roon zone configuration is properly stored.
+  - Already configured entities can be left as is, they will work as long as the Roon zone is still available.
+  - Roon zone configuration is now locally stored at the time of setup. New zones won't automatically create a new media-player entity ([#57](https://github.com/unfoldedcircle/integration-roon/pull/57)).
+
+### Fixed
+
+- Handle Roon core pairing / unpairing and zone added / removed events to set media-player entity state ([#57](https://github.com/unfoldedcircle/integration-roon/pull/57)).
+
+### Changed
+
+- Setup instructions at the start of the integration setup flow.
+- Use debug module for logging ([#53](https://github.com/unfoldedcircle/integration-roon/issues/53)).
+
 ---
 
 ## 0.3.0 - 2024-12-19

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm run build
 Run as external integration driver:
 
 ```shell
-UC_CONFIG_HOME=. UC_INTEGRATION_HTTP_PORT=8079 node dist/index.js
+UC_CONFIG_HOME=. UC_INTEGRATION_HTTP_PORT=8079 npm run start
 ```
 
 The configuration files are loaded & saved from the path specified in the environment variable `UC_CONFIG_HOME`.
@@ -53,13 +53,26 @@ The configuration files are loaded & saved from the path specified in the enviro
 
 ### Logging
 
-The [Unfolded Circle Integration-API library](https://github.com/unfoldedcircle/integration-node-library) is using the
-[debug](https://www.npmjs.com/package/debug) module for logging.
-
-To enable the integration library logging, run the driver with the `DEBUG` environment variable set like:
+Logging any kind of output is directed to the [debug](https://www.npmjs.com/package/debug) module.
+To let the integration driver output anything, run the driver with the `DEBUG` environment variable set like:
 
 ```shell
-DEBUG=* node dist/index.js
+DEBUG=roon:* npm run start
+```
+
+The driver exposes the following log-levels:
+
+Log namespaces:
+
+- `roon:debug`: debugging messages
+- `roon:info`: informational messages like server up and running, device connected or disconnected
+- `roon:warn`: warnings
+- `roon:error`: errors
+
+If you only want to get errors and warnings reported:
+
+```shell
+DEBUG=roon:warn,roon:error npm run start
 ```
 
 Additional information:

--- a/driver.json
+++ b/driver.json
@@ -1,9 +1,9 @@
 {
   "driver_id": "uc_roon_driver",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "min_core_api": "0.20.0",
   "name": { "en": "Roon" },
-  "icon": "uc:integration",
+  "icon": "uc:music",
   "description": {
     "en": "Control Roon with Remote Two/3.",
     "de": "Steuere Roon mit Remote Two/3."
@@ -29,13 +29,13 @@
         "field": {
           "label": {
             "value": {
-              "en": "The integration will enable an extension for Roon on your network.",
-              "de": "Diese Integration ermöglicht die Steuerung von Roon im Netzwerk."
+              "en": "- The integration will enable an extension for Roon on your network.\n- The extension needs to be authorized in the Roon application under _Settings, Extensions_.\n- All available Roon zones at the time of the setup process are stored in the integration.\n- To add or remove a zone, the setup needs to be run again.\n- A media-player entity is created for each zone to control playback and show media artwork.",
+              "de": "- Die Integration wird eine Erweiterung für Roon in Ihrem Netzwerk aktivieren.\n- Die Erweiterung muss in der Roon-Anwendung unter _Einstellungen, Erweiterungen_ autorisiert werden.\n- Alle zum Zeitpunkt des Setup-Prozesses verfügbaren Roon-Zonen werden in der Integration gespeichert.\n- Um eine Zone hinzuzufügen oder zu entfernen, muss das Setup erneut ausgeführt werden.\n- Für jede Zone wird eine Medienplayer-Entität erstellt, um die Wiedergabe zu steuern und Mediencover anzuzeigen."
             }
           }
         }
       }
     ]
   },
-  "release_date": "2024-12-19"
+  "release_date": "2024-12-28"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "uc-integration-roon",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uc-integration-roon",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@unfoldedcircle/integration-api": "^0.2.2",
+        "debug": "^4.4.0",
         "node-roon-api": "github:unfoldedcircle/node-roon-api#a34b5deaaa30ed811f0b325316dcfbd489ad41a3",
         "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
         "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
@@ -17,6 +18,7 @@
         "ws": "^8.18.0"
       },
       "devDependencies": {
+        "@types/debug": "^4.1.12",
         "@types/node": "^22.10.1",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
@@ -195,10 +197,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uc-integration-roon",
   "type": "module",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Roon Integration for the Unfolded Circle",
   "main": "dist/index.js",
   "scripts": {
@@ -16,6 +16,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@unfoldedcircle/integration-api": "^0.2.2",
+    "debug": "^4.4.0",
     "node-roon-api": "github:unfoldedcircle/node-roon-api#a34b5deaaa30ed811f0b325316dcfbd489ad41a3",
     "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
     "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
@@ -23,6 +24,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/node": "^22.10.1",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,11 @@ class Config {
     this.saveToFile();
   }
 
+  public hasZone(zoneId: string): boolean {
+    const zone = this.getZone(zoneId);
+    return !!zone;
+  }
+
   public getZone(zoneId: string): Zone | null {
     return this.zones[zoneId] ?? null;
   }

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -1,0 +1,20 @@
+/**
+ * Central log functions.
+ *
+ * Use [debug](https://www.npmjs.com/package/debug) module for logging.
+ *
+ * @copyright (c) 2024 by Unfolded Circle ApS.
+ * @license Mozilla Public License Version 2.0, see LICENSE for more details.
+ */
+
+import debugModule from "debug";
+
+const log = {
+  msgTrace: debugModule("roon:msg"),
+  debug: debugModule("roon:debug"),
+  info: debugModule("roon:info"),
+  warn: debugModule("roon:warn"),
+  error: debugModule("roon:error")
+};
+
+export default log;

--- a/src/roon-integration.ts
+++ b/src/roon-integration.ts
@@ -7,6 +7,7 @@
 
 import * as uc from "@unfoldedcircle/integration-api";
 import { AbortDriverSetup } from "@unfoldedcircle/integration-api";
+import log from "./loggers.js";
 import RoonApi, { Core, Zone } from "node-roon-api";
 import RoonApiImage from "node-roon-api-image";
 import RoonApiStatus from "node-roon-api-status";
@@ -58,7 +59,7 @@ export default class RoonDriver {
     if (msg instanceof uc.UserConfirmationResponse) {
       return this.handleDriverSetupUserConfirmation(msg);
     }
-    console.error("[uc_roon] Unknown Roon integration setup message", msg);
+    log.error("Unknown Roon integration setup message", msg);
     return new uc.AbortDriverSetup("Unknown Roon integration setup message");
   }
 
@@ -68,7 +69,7 @@ export default class RoonDriver {
     }
     const img = convertImageToBase64("./assets/setupimg.png");
     if (!img) {
-      console.error("[uc_roon] Failed to convert image to base64");
+      log.error("Failed to convert image to base64");
       return new AbortDriverSetup("Failed to process image during setup");
     }
     return new uc.RequestUserConfirmation(
@@ -90,8 +91,12 @@ export default class RoonDriver {
     return new uc.SetupError("Failed to pair with Roon");
   }
 
+  /**
+   * Load saved configuration and create an available media-player entity for each zone.
+   */
   private initLocalZones() {
     this.config.forEachZone((zone) => {
+      log.info(`Creating media-player for configured zone: ${zone.display_name} (${zone.zone_id})`);
       const entity = newEntityFromZone(zone, true);
       entity.setCmdHandler(this.handleEntityCommand.bind(this));
       this.driver.addAvailableEntity(entity);
@@ -118,19 +123,19 @@ export default class RoonDriver {
 
   private async handleSubscribeEntities(entityIds: string[]) {
     if (!this.roonCore) {
-      console.warn("[uc_roon] Can't send entity data after subscribe: Roon core not available");
+      log.warn("Can't send entity data after subscribe: Roon core not available");
       return;
     }
 
     entityIds.forEach((entityId) => {
       const entity = this.driver.getConfiguredEntities().getEntity(entityId);
       if (entity) {
-        console.log(`[uc_roon] Subscribe: ${entityId}`);
+        log.info(`Subscribe: ${entityId}`);
 
         // update entity with current Zone information
         const zone = this.roonTransport?.zone_by_zone_id(entityId);
         if (zone) {
-          console.log(`[uc_roon] Zone data: ${JSON.stringify(zone)}`);
+          log.info(`Zone data: ${JSON.stringify(zone)}`);
           const attr = mediaPlayerAttributesFromZone(zone);
           this.driver.getConfiguredEntities().updateEntityAttributes(entity.id, attr);
         } else {
@@ -148,21 +153,23 @@ export default class RoonDriver {
   }
 
   private async handleEnterStandby() {
-    this.roonApiStatus?.set_status("Disconnected", false);
+    log.info("enter standby");
+    this.roonApiStatus?.set_status("Standby", false);
   }
 
   private async handleExitStandby() {
+    log.info("exit standby");
     this.roonApiStatus?.set_status("Connected", false);
   }
 
   private async subscribeRoonZones() {
     if (this.roonCore == null) {
-      console.warn("[uc_roon] Cannot subscribe to Roon zones. RoonCore is null.");
+      log.warn("Cannot subscribe to Roon zones. RoonCore is null.");
       return;
     }
 
     if (this.roonTransport == null) {
-      console.warn("[uc_roon] Cannot subscribe to Roon zones. RoonTransport is null.");
+      log.warn("Cannot subscribe to Roon zones. RoonTransport is null.");
       return;
     }
 
@@ -173,13 +180,13 @@ export default class RoonDriver {
           const data = msg as SubscribeZoneChanged;
           if (data.zones_changed) {
             data.zones_changed.forEach((zone: Zone) => {
-              console.log(`[uc_roon] Change: ${zone.display_name} (${zone.zone_id})`);
+              log.info(`Zone changed: ${zone.display_name} (${zone.zone_id})`);
               this.updateMediaPlayerFromZone(zone);
             });
           } else if (data.zones_seek_changed) {
             data.zones_seek_changed.forEach((zone) => {
               if (!this.driver.getConfiguredEntities().contains(zone.zone_id)) {
-                console.log(`[uc_roon] Configured entity not found, not updating seek:(${zone.zone_id})`);
+                log.info(`Configured entity not found, not updating seek:(${zone.zone_id})`);
                 return;
               }
 
@@ -194,8 +201,9 @@ export default class RoonDriver {
           const data = msg as SubscribeZoneSubscribed;
           if (data.zones) {
             data.zones.forEach((zone) => {
-              console.log(`[uc_roon] Subscribed: ${zone.display_name} (${zone.zone_id})`);
-              this.updateMediaPlayerFromZone(zone);
+              if (this.updateMediaPlayerFromZone(zone)) {
+                log.info(`Subscribed: ${zone.display_name} (${zone.zone_id})`);
+              }
             });
           }
           break;
@@ -209,13 +217,13 @@ export default class RoonDriver {
    *
    * @param {Object} zone The Roon zone
    */
-  private updateMediaPlayerFromZone(zone: Zone) {
+  private updateMediaPlayerFromZone(zone: Zone): boolean {
     if (!zone) {
-      return;
+      return false;
     }
     if (!this.driver.getConfiguredEntities().contains(zone.zone_id)) {
-      console.log(`[uc_roon] Configured entity not found, not updating: ${zone.display_name} (${zone.zone_id})`);
-      return;
+      log.info(`Configured entity not found, not updating: ${zone.display_name} (${zone.zone_id})`);
+      return false;
     }
     const attr = mediaPlayerAttributesFromZone(zone);
     if (zone.now_playing) {
@@ -233,7 +241,7 @@ export default class RoonDriver {
           },
           (error, contentType, image) => {
             if (error) {
-              console.warn(`[uc_roon] Failed to get image: ${error}`);
+              log.warn(`Failed to get image: ${error}`);
             } else if (image) {
               this.driver.getConfiguredEntities().updateEntityAttributes(zone.zone_id, {
                 [uc.MediaPlayerAttributes.MediaImageUrl]: "data:image/png;base64," + image.toString("base64")
@@ -243,7 +251,7 @@ export default class RoonDriver {
         );
       }
     }
-    this.driver.getConfiguredEntities().updateEntityAttributes(zone.zone_id, attr);
+    return this.driver.getConfiguredEntities().updateEntityAttributes(zone.zone_id, attr);
   }
 
   private async handleRoonCorePaired(core: Core) {
@@ -252,14 +260,14 @@ export default class RoonDriver {
     this.roonImage = new RoonApiImage(core);
     this.roonTransport = core.services.RoonApiTransport as RoonApiTransport;
 
-    console.log(`[uc_roon] Roon Core paired: ${core.core_id} ${core.display_name} ${core.display_version}`);
+    log.info(`Roon Core paired: ${core.core_id} ${core.display_name} ${core.display_version}`);
 
     await this.getRoonZones();
     await this.subscribeRoonZones();
   }
 
   private handleRoonCoreUnpaired() {
-    console.log("[uc_roon] Roon Core unpaired");
+    log.info("Roon Core unpaired");
     this.roonPaired = false;
     this.roonCore = null;
     this.roonImage = null;
@@ -267,19 +275,19 @@ export default class RoonDriver {
 
   private async getRoonZones(): Promise<void> {
     if (this.roonCore == null) {
-      console.warn("[uc_roon] Cannot get Roon zones. RoonCore is null.");
+      log.warn("Cannot get Roon zones. RoonCore is null.");
       return;
     }
 
     if (this.roonTransport == null) {
-      console.warn("[uc_roon] Cannot get Roon zones. RoonTransport is null.");
+      log.warn("Cannot get Roon zones. RoonTransport is null.");
       return;
     }
 
     return new Promise((resolve, reject) => {
       this.roonTransport.get_zones(async (error, data) => {
         if (error) {
-          console.warn("[uc_roon] Failed to get Roon Zones");
+          log.warn("Failed to get Roon Zones");
           reject(error);
         }
 
@@ -287,7 +295,7 @@ export default class RoonDriver {
         // so we can keep track of available zones
         this.config.clear();
         for (const zone of data.zones) {
-          console.log(`[uc_roon] Found available zone: ${zone.display_name} (${zone.zone_id})`);
+          log.info(`Found available zone: ${zone.display_name} (${zone.zone_id})`);
           const res = this.driver.getAvailableEntities().getEntity(zone.zone_id);
           if (!res) {
             const entity = newEntityFromZone(zone);
@@ -307,12 +315,12 @@ export default class RoonDriver {
     params?: { [key: string]: string | number | boolean }
   ): Promise<uc.StatusCodes> {
     if (!this.roonPaired) {
-      console.error(`[uc_roon] Roon is not paired. Not executing command ${command}`);
+      log.error(`Roon is not paired. Not executing command ${command}`);
       return uc.StatusCodes.ServerError;
     }
 
     if (!this.roonTransport) {
-      console.error(`[uc_roon] RoonTransport is not initialized. Not executing command ${command}`);
+      log.error(`RoonTransport is not initialized. Not executing command ${command}`);
       return uc.StatusCodes.ServerError;
     }
 
@@ -323,7 +331,7 @@ export default class RoonDriver {
             entity?.attributes?.[uc.MediaPlayerAttributes.State] === uc.MediaPlayerStates.Playing ? "pause" : "play";
           this.roonTransport.control(entity.id, roonCmd, async (error) => {
             if (error) {
-              console.error(`[uc_roon] Error on ${roonCmd} media player: ${error}`);
+              log.error(`Error on ${roonCmd} media player: ${error}`);
               resolve(uc.StatusCodes.ServerError);
             } else {
               resolve(uc.StatusCodes.Ok);
@@ -334,7 +342,7 @@ export default class RoonDriver {
         case uc.MediaPlayerCommands.Next:
           this.roonTransport.control(entity.id, "next", async (error) => {
             if (error) {
-              console.error(`[uc_roon] Error next media player: ${error}`);
+              log.error(`Error next media player: ${error}`);
               resolve(uc.StatusCodes.ServerError);
             } else {
               resolve(uc.StatusCodes.Ok);
@@ -344,7 +352,7 @@ export default class RoonDriver {
         case uc.MediaPlayerCommands.Previous:
           this.roonTransport.control(entity.id, "previous", async (error) => {
             if (error) {
-              console.error(`[uc_roon] Error previous media player: ${error}`);
+              log.error(`Error previous media player: ${error}`);
               resolve(uc.StatusCodes.ServerError);
             } else {
               resolve(uc.StatusCodes.Ok);
@@ -356,7 +364,7 @@ export default class RoonDriver {
           if (output) {
             this.roonTransport.change_volume(output.output_id, "absolute", Number(params?.volume), async (error) => {
               if (error) {
-                console.error(`[uc_roon] Error changing volume media player: ${error}`);
+                log.error(`Error changing volume media player: ${error}`);
                 resolve(uc.StatusCodes.ServerError);
               } else {
                 resolve(uc.StatusCodes.Ok);
@@ -370,14 +378,14 @@ export default class RoonDriver {
           if (output) {
             this.roonTransport.change_volume(output.output_id, "relative_step", 1, async (error) => {
               if (error) {
-                console.error(`[uc_roon] Error changing volume media player: ${error}`);
+                log.error(`Error changing volume media player: ${error}`);
                 resolve(uc.StatusCodes.ServerError);
               } else {
                 resolve(uc.StatusCodes.Ok);
               }
             });
           } else {
-            console.error(`[uc_roon] Volume up, output not found, entity:${entity.id}`);
+            log.error(`Volume up, output not found, entity:${entity.id}`);
             resolve(uc.StatusCodes.ServiceUnavailable);
           }
           break;
@@ -387,7 +395,7 @@ export default class RoonDriver {
           if (output) {
             this.roonTransport.change_volume(output.output_id, "relative_step", -1, async (error) => {
               if (error) {
-                console.error(`[uc_roon] Error changing volume media player: ${error}`);
+                log.error(`Error changing volume media player: ${error}`);
                 resolve(uc.StatusCodes.ServerError);
               } else {
                 resolve(uc.StatusCodes.Ok);
@@ -402,7 +410,7 @@ export default class RoonDriver {
             const roonCmd = entity.attributes?.[uc.MediaPlayerAttributes.Muted] ? "unmute" : "mute";
             this.roonTransport.mute(output.output_id, roonCmd, async (error) => {
               if (error) {
-                console.error(`[uc_roon] Error on ${roonCmd} media player: ${error}`);
+                log.error(`Error on ${roonCmd} media player: ${error}`);
                 resolve(uc.StatusCodes.ServerError);
               } else {
                 resolve(uc.StatusCodes.Ok);
@@ -414,7 +422,7 @@ export default class RoonDriver {
         case uc.MediaPlayerCommands.Seek:
           this.roonTransport.seek(entity.id, "absolute", Number(params?.media_position), async (error) => {
             if (error) {
-              console.error(`[uc_roon] Error seeking media player: ${error}`);
+              log.error(`Error seeking media player: ${error}`);
               resolve(uc.StatusCodes.ServerError);
             } else {
               resolve(uc.StatusCodes.Ok);
@@ -422,7 +430,7 @@ export default class RoonDriver {
           });
           break;
         default:
-          console.warn(`[uc_roon] Unknown entity command: ${command}`);
+          log.warn(`Unknown entity command: ${command}`);
           resolve(uc.StatusCodes.BadRequest);
       }
     });

--- a/src/roon-integration.ts
+++ b/src/roon-integration.ts
@@ -316,12 +316,14 @@ export default class RoonDriver {
   ): Promise<uc.StatusCodes> {
     if (!this.roonPaired) {
       log.error(`Roon is not paired. Not executing command ${command}`);
-      return uc.StatusCodes.ServerError;
+      this.setEntityState(entity.id, uc.MediaPlayerStates.Unavailable);
+      return uc.StatusCodes.ServiceUnavailable;
     }
 
     if (!this.roonTransport) {
       log.error(`RoonTransport is not initialized. Not executing command ${command}`);
-      return uc.StatusCodes.ServerError;
+      this.setEntityState(entity.id, uc.MediaPlayerStates.Unavailable);
+      return uc.StatusCodes.ServiceUnavailable;
     }
 
     return new Promise((resolve) => {
@@ -438,6 +440,12 @@ export default class RoonDriver {
 
   private getDefaultZoneOutput(zoneId: string) {
     return this.config.getZone(zoneId)?.outputs?.[0];
+  }
+
+  private setEntityState(entityId: string, state: uc.MediaPlayerStates) {
+    this.driver.getConfiguredEntities().updateEntityAttributes(entityId, {
+      [uc.MediaPlayerAttributes.State]: state
+    });
   }
 
   async init() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,16 +31,17 @@ export const mediaPlayerAttributesFromZone = (zone: Zone) => {
   }
 
   // state
+  let state = uc.MediaPlayerStates.Unknown;
   switch (zone.state) {
     case "playing":
-      attr[uc.MediaPlayerAttributes.State] = uc.MediaPlayerStates.Playing;
+      state = uc.MediaPlayerStates.Playing;
       break;
-
     case "stopped":
     case "paused":
-      attr[uc.MediaPlayerAttributes.State] = uc.MediaPlayerStates.Paused;
+      state = uc.MediaPlayerStates.Paused;
       break;
   }
+  attr[uc.MediaPlayerAttributes.State] = state;
 
   if (zone.outputs && zone.outputs[0] && zone.outputs[0].volume) {
     // volume

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,6 +6,7 @@
  */
 
 import fs from "fs";
+import log from "./loggers.js";
 import * as uc from "@unfoldedcircle/integration-api";
 import { Zone } from "node-roon-api";
 export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -16,7 +17,7 @@ export const convertImageToBase64 = (file: fs.PathOrFileDescriptor) => {
   try {
     data = fs.readFileSync(file, "base64");
   } catch (e) {
-    console.log(e);
+    log.error(e);
   }
 
   return data;

--- a/types/roon-transport.d.ts
+++ b/types/roon-transport.d.ts
@@ -16,6 +16,8 @@ declare module "node-roon-api-transport" {
   };
 
   type SubscribeZoneChanged = {
+    zones_added?: Zone[];
+    zones_removed?: string[];
     zones_changed?: Zone[];
     zones_seek_changed?: {
       zone_id: string;
@@ -48,7 +50,7 @@ declare module "node-roon-api-transport" {
     group_outputs(outputs: (Output | string)[], cb?: ResultCallback): void;
     ungroup_outputs(outputs: (Output | string)[], cb?: ResultCallback): void;
     change_settings(zoneOrOutput: Zone | Output | string, settings: ZoneSettings, cb?: ResultCallback): void;
-    get_zones(cb: (error: false | string, body: { zones: Zone[] }) => void): void;
+    get_zones(cb?: (error: false | string, body: { zones: Zone[] }) => void): void;
     get_outputs(cb: (error: false | string, body: { outputs: Output[] }) => void): void;
     subscribe_outputs(cb: (response: string, msg: any) => void): void;
     subscribe_zones(cb: (response: SubscribeZoneResponse, msg: SubscribeZoneMsg) => void): void;


### PR DESCRIPTION
Improve entity handling with setting correct state, depending on Roon communication and zones availability. Relates to some issues described in #56:

- Set entity state in command handler if Roon is not paired.
  Set the media-player entity to unavailable, if an entity command is received, but Roon is either not paired or no transport available.

  This makes the entity unavailable in the UI and prevents further command
failures until Roon core becomes available again.

- Handle Roon core pairing and unpairing events.
  Once the integration is no longer paired to the Roon core, we can't send transport commands anymore. Set the media-player entity states to `unavailable` to indicate the disconnection state in the UI and prevent sending further commands.

  For the pairing event we may not clear our zone information stored
during setup. Also, prevent to dynamically add new zones. Adding or
removing zones require to run the integration setup.

- Enable and disable media-player entities if a Roon zone was removed or re-added again.

Other changes:
- Closes #53 
- Improved setup descriptions and using a music icon for the integration:
<img width="547" alt="image" src="https://github.com/user-attachments/assets/808bc01c-8d3f-498e-be70-4d9aba27adfe" />
