### PR TITLE
feat: add shuffle and repeat support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+
+- Shuffle and repeat ([#28](https://github.com/unfoldedcircle/integration-roon/issues/28)).
+
 ---
 
 ## 0.3.1 - 2024-12-28

--- a/src/roon-integration.ts
+++ b/src/roon-integration.ts
@@ -13,7 +13,7 @@ import RoonApiImage from "node-roon-api-image";
 import RoonApiStatus from "node-roon-api-status";
 import RoonApiTransport, { SubscribeZoneChanged, SubscribeZoneSubscribed } from "node-roon-api-transport";
 import Config from "./config.js";
-import { convertImageToBase64, delay, mediaPlayerAttributesFromZone, newEntityFromZone } from "./util.js";
+import { convertImageToBase64, delay, getLoopMode, mediaPlayerAttributesFromZone, newEntityFromZone } from "./util.js";
 
 import os from "os";
 
@@ -474,6 +474,28 @@ export default class RoonDriver {
           this.roonTransport?.seek(entity.id, "absolute", Number(params?.media_position), async (error) => {
             if (error) {
               log.error(`Error seeking media player: ${error}`);
+              resolve(uc.StatusCodes.ServerError);
+            } else {
+              resolve(uc.StatusCodes.Ok);
+            }
+          });
+          break;
+        case uc.MediaPlayerCommands.Shuffle:
+          const shuffle = !!params?.shuffle;
+          this.roonTransport?.change_settings(entity.id, { shuffle }, async (error) => {
+            if (error) {
+              log.error(`Shuffle error: ${error}`);
+              resolve(uc.StatusCodes.ServerError);
+            } else {
+              resolve(uc.StatusCodes.Ok);
+            }
+          });
+          break;
+        case uc.MediaPlayerCommands.Repeat:
+          let loop = getLoopMode(params?.repeat.toString());
+          this.roonTransport?.change_settings(entity.id, { loop }, async (error) => {
+            if (error) {
+              log.error(`Repeat error: ${error}`);
               resolve(uc.StatusCodes.ServerError);
             } else {
               resolve(uc.StatusCodes.Ok);

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,9 @@
 import fs from "fs";
 import log from "./loggers.js";
 import * as uc from "@unfoldedcircle/integration-api";
-import { Zone } from "node-roon-api";
+import { RepeatMode } from "@unfoldedcircle/integration-api";
+import { LoopSetting, Zone } from "node-roon-api";
+
 export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export const convertImageToBase64 = (file: fs.PathOrFileDescriptor) => {
@@ -78,8 +80,33 @@ export const mediaPlayerAttributesFromZone = (zone: Zone) => {
   attr[uc.MediaPlayerAttributes.MediaDuration] = mediaDuration;
   attr[uc.MediaPlayerAttributes.MediaPosition] = mediaPosition;
 
+  attr[uc.MediaPlayerAttributes.Shuffle] = !!zone.settings?.shuffle;
+  attr[uc.MediaPlayerAttributes.Repeat] = getRepeatMode(zone);
+
   return attr;
 };
+
+export function getLoopMode(repeat: string | undefined): LoopSetting {
+  switch (repeat) {
+    case RepeatMode.All:
+      return "loop";
+    case RepeatMode.One:
+      return "loop_one";
+    default:
+      return "disabled";
+  }
+}
+
+function getRepeatMode(zone: Zone): RepeatMode {
+  switch (zone.settings?.loop) {
+    case "loop":
+      return RepeatMode.All;
+    case "loop_one":
+      return RepeatMode.One;
+    default:
+      return RepeatMode.Off;
+  }
+}
 
 export function newEntityFromZone(zone: Zone, emptyAttributes: boolean = false) {
   const features = [
@@ -94,7 +121,9 @@ export function newEntityFromZone(zone: Zone, emptyAttributes: boolean = false) 
     uc.MediaPlayerFeatures.MediaTitle,
     uc.MediaPlayerFeatures.MediaArtist,
     uc.MediaPlayerFeatures.MediaAlbum,
-    uc.MediaPlayerFeatures.MediaImageUrl
+    uc.MediaPlayerFeatures.MediaImageUrl,
+    uc.MediaPlayerFeatures.Shuffle,
+    uc.MediaPlayerFeatures.Repeat
   ];
 
   // TODO add & test REPEAT, SHUFFLE


### PR DESCRIPTION
Add support for shuffle and repeat one & repeat all.

To update already configured media-player entities in the Remote with these features:
1. Open Web-configurator
2. Go to: integrations
3. Open the Roon integration
4. Done (entities are automatically synchronized with new features)

Closes #28