### PR TITLE
feat: disconnect & reconnect Roon during standby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ _Changes in the next release_
 
 ### Fixed
 
-- Much faster reconnection to Roon core after waking up from standby ([#56](https://github.com/unfoldedcircle/integration-roon/pull/56)).
+- Much faster reconnection to Roon core after waking up from standby ([#59](https://github.com/unfoldedcircle/integration-roon/pull/59)).
+- Sporadic runtime crashes in RoonApi library ([#19](https://github.com/unfoldedcircle/integration-roon/issues/19)).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ _Changes in the next release_
 
 - Shuffle and repeat ([#28](https://github.com/unfoldedcircle/integration-roon/issues/28)).
 
+### Fixed
+
+- Much faster reconnection to Roon core after waking up from standby ([#56](https://github.com/unfoldedcircle/integration-roon/pull/56)).
+
 ---
 
 ## 0.3.1 - 2024-12-28

--- a/README.md
+++ b/README.md
@@ -62,17 +62,31 @@ DEBUG=roon:* npm run start
 
 The driver exposes the following log-levels:
 
-Log namespaces:
+Log namespaces of the integration driver:
 
 - `roon:debug`: debugging messages
 - `roon:info`: informational messages like server up and running, device connected or disconnected
 - `roon:warn`: warnings
 - `roon:error`: errors
 
-If you only want to get errors and warnings reported:
+Log namespaces of the Roon API library:
+
+- `roonapi:msg`: message trace of WebSocket communication and SOOD discovery
+- `roonapi:debug`
+- `roonapi:info`
+- `roonapi:warn`
+- `roonapi:error`
+
+If you only want to get errors and warnings reported of the integration:
 
 ```shell
 DEBUG=roon:warn,roon:error npm run start
+```
+
+Errors and warnings of the Roon API and the integration:
+
+```shell
+DEBUG=roonapi:warn,roonapi:error,roon:warn,roon:error npm run start
 ```
 
 Additional information:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@unfoldedcircle/integration-api": "^0.2.2",
         "debug": "^4.4.0",
-        "node-roon-api": "github:unfoldedcircle/node-roon-api#0867d54212db8a23fc2a27628e72a9fbd800d384",
+        "node-roon-api": "github:unfoldedcircle/node-roon-api#951a54534a6dae40740e81e49f3eb0a552b21442",
         "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
         "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
         "node-roon-api-transport": "github:roonlabs/node-roon-api-transport#2ee60008a4cdb90c34ff3de58bb4b949067f1d20",
@@ -2692,8 +2692,8 @@
     },
     "node_modules/node-roon-api": {
       "version": "1.2.3",
-      "resolved": "git+ssh://git@github.com/unfoldedcircle/node-roon-api.git#0867d54212db8a23fc2a27628e72a9fbd800d384",
-      "integrity": "sha512-I7cM2FtmUML9GBd6DEC2dooD49O+gV8UqttYJZTeWQIFz0SEibodFCS9r8Idl1qfE43mm+wzPa+AEu0flB1ywg==",
+      "resolved": "git+ssh://git@github.com/unfoldedcircle/node-roon-api.git#951a54534a6dae40740e81e49f3eb0a552b21442",
+      "integrity": "sha512-KHrooAkNt9NGNqeKxoqhul0pL10ILHThKm6s1NduDr5+kAgyziFUTX9yFbjKrlF/73c6cxW6b1mfnASHolkhLw==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@unfoldedcircle/integration-api": "^0.2.2",
         "debug": "^4.4.0",
-        "node-roon-api": "github:unfoldedcircle/node-roon-api#a3f7ba37e154ac822166bb09afa49f228fd28114",
+        "node-roon-api": "github:unfoldedcircle/node-roon-api#0867d54212db8a23fc2a27628e72a9fbd800d384",
         "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
         "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
         "node-roon-api-transport": "github:roonlabs/node-roon-api-transport#2ee60008a4cdb90c34ff3de58bb4b949067f1d20",
@@ -2692,7 +2692,7 @@
     },
     "node_modules/node-roon-api": {
       "version": "1.2.3",
-      "resolved": "git+ssh://git@github.com/unfoldedcircle/node-roon-api.git#a3f7ba37e154ac822166bb09afa49f228fd28114",
+      "resolved": "git+ssh://git@github.com/unfoldedcircle/node-roon-api.git#0867d54212db8a23fc2a27628e72a9fbd800d384",
       "integrity": "sha512-I7cM2FtmUML9GBd6DEC2dooD49O+gV8UqttYJZTeWQIFz0SEibodFCS9r8Idl1qfE43mm+wzPa+AEu0flB1ywg==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@unfoldedcircle/integration-api": "^0.2.2",
         "debug": "^4.4.0",
-        "node-roon-api": "github:unfoldedcircle/node-roon-api#a34b5deaaa30ed811f0b325316dcfbd489ad41a3",
+        "node-roon-api": "github:unfoldedcircle/node-roon-api#a3f7ba37e154ac822166bb09afa49f228fd28114",
         "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
         "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
         "node-roon-api-transport": "github:roonlabs/node-roon-api-transport#2ee60008a4cdb90c34ff3de58bb4b949067f1d20",
@@ -2039,9 +2039,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "license": "MIT"
     },
     "node_modules/is-array-buffer": {
@@ -2692,12 +2692,13 @@
     },
     "node_modules/node-roon-api": {
       "version": "1.2.3",
-      "resolved": "git+ssh://git@github.com/unfoldedcircle/node-roon-api.git#a34b5deaaa30ed811f0b325316dcfbd489ad41a3",
-      "integrity": "sha512-CAtRgEwY78Tzgjdu1geEu+3i7X2P0V6t1OSLZj+2mK9kF7DqE3cDA5Kz7p8l3Y/vjLLCi5/XVkp1+cc0YNHKKg==",
+      "resolved": "git+ssh://git@github.com/unfoldedcircle/node-roon-api.git#a3f7ba37e154ac822166bb09afa49f228fd28114",
+      "integrity": "sha512-I7cM2FtmUML9GBd6DEC2dooD49O+gV8UqttYJZTeWQIFz0SEibodFCS9r8Idl1qfE43mm+wzPa+AEu0flB1ywg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "ip": "^1.1.3",
-        "node-uuid": "^1.4.7",
+        "debug": "^4.4.0",
+        "ip": "^2.0.1",
+        "node-uuid": "^1.4.8",
         "ws": ">=3.3.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@unfoldedcircle/integration-api": "^0.2.2",
     "debug": "^4.4.0",
-    "node-roon-api": "github:unfoldedcircle/node-roon-api#a34b5deaaa30ed811f0b325316dcfbd489ad41a3",
+    "node-roon-api": "github:unfoldedcircle/node-roon-api#a3f7ba37e154ac822166bb09afa49f228fd28114",
     "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
     "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
     "node-roon-api-transport": "github:roonlabs/node-roon-api-transport#2ee60008a4cdb90c34ff3de58bb4b949067f1d20",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@unfoldedcircle/integration-api": "^0.2.2",
     "debug": "^4.4.0",
-    "node-roon-api": "github:unfoldedcircle/node-roon-api#a3f7ba37e154ac822166bb09afa49f228fd28114",
+    "node-roon-api": "github:unfoldedcircle/node-roon-api#0867d54212db8a23fc2a27628e72a9fbd800d384",
     "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
     "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
     "node-roon-api-transport": "github:roonlabs/node-roon-api-transport#2ee60008a4cdb90c34ff3de58bb4b949067f1d20",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@unfoldedcircle/integration-api": "^0.2.2",
     "debug": "^4.4.0",
-    "node-roon-api": "github:unfoldedcircle/node-roon-api#0867d54212db8a23fc2a27628e72a9fbd800d384",
+    "node-roon-api": "github:unfoldedcircle/node-roon-api#951a54534a6dae40740e81e49f3eb0a552b21442",
     "node-roon-api-image": "github:roonlabs/node-roon-api-image#a5f0efaf2dfb5457e91abe326c3a40d865131d32",
     "node-roon-api-status": "github:roonlabs/node-roon-api-status#504c918d6da267e03fbb4337befa71ca3d3c7526",
     "node-roon-api-transport": "github:roonlabs/node-roon-api-transport#2ee60008a4cdb90c34ff3de58bb4b949067f1d20",

--- a/types/roon-api.d.ts
+++ b/types/roon-api.d.ts
@@ -191,8 +191,6 @@ declare module "node-roon-api" {
     email: string;
     /** (Optional) Website for more information about the extension. */
     website?: string;
-    /** Determines the level of logging: "all", "none", or other values for selective logging. */
-    log_level: string;
     /** (Optional) Directory to store configuration files. */
     configDir?: string;
     /** (Optional) Callback invoked when Roon pairs your extension with a Core. */
@@ -224,6 +222,20 @@ declare module "node-roon-api" {
      * Begins the discovery process to find/connect to a Roon Core.
      */
     start_discovery(): void;
+
+    /**
+     * Stop the discovery process to automatically connect to a Roon core.
+     *
+     * To restart the discovery process, call `start_discovery` again.
+     */
+    stop_discovery(): void;
+
+    /**
+     * Disconnect all Roon core WebSocket connections.
+     *
+     * To remain disconnected, call `stop_discovery` first.
+     */
+    disconnect_all(): void;
 
     /**
      * Internal method for periodic scanning during discovery.


### PR DESCRIPTION
Reduce Roon core reconnection time after leaving standby. This previously took around 10-70s. Now most time the reconnection only takes around 1-2s.

- Stop discovery and disconnect from Roon when entering standby.
- Restart discovery (with auto-connect) after leaving standby.
- Make sure Roon discovery is started when Remote device connects.
- Use debug module in Roon API.

Closes #56 

Other fixes due to patched node-roon-api module:
- Fixes #19 